### PR TITLE
Appveyor csproj patching

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   major: 3
   minor: 0
-  patch: 0
+  patch: 1
 
 image: Visual Studio 2017
 configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,35 @@
-version: '3.0.0.{build}'
+environment:
+  major: 3
+  minor: 0
+  patch: 0
+
 image: Visual Studio 2017
-platform: Any CPU
+configuration: Release
+
+dotnet_csproj:
+  patch: true
+  version: '{version}'
+  file: src\Serilog.Sinks.TestCorrelator\Serilog.Sinks.TestCorrelator.csproj
+
 before_build:
-- dotnet restore
-build_script:
-- dotnet build .\src\Serilog.Sinks.TestCorrelator\Serilog.Sinks.TestCorrelator.csproj /property:Configuration=Release /property:Version=%APPVEYOR_BUILD_VERSION%
-artifacts:
-- path: '**\*.nupkg'
-test_script:
-- dotnet test .\test\Serilog.Sinks.TestCorrelator.Tests\Serilog.Sinks.TestCorrelator.Tests.csproj /property:Configuration=Release
-deploy:
-- provider: NuGet
-  api_key:
-    secure: nrvEl2qb2BnEzXO8I3wdMRCawAa8hMpiVbmNBciLPagEaBmeJyA5yM4Ntdj7M0To
-  on:
-    branch: master
+ - nuget restore
+
+build:
+  publish_nuget: true
+  publish_nuget_symbols: true
+
+for:
+  - branches:
+      except:
+        - master
+    version: $(major).$(minor).$(patch)+{branch}-{build}
+  
+  - branches:
+      only:
+        - master
+    version: $(major).$(minor).$(patch)
+    deploy:
+      - provider: NuGet
+        api_key:
+          secure: nrvEl2qb2BnEzXO8I3wdMRCawAa8hMpiVbmNBciLPagEaBmeJyA5yM4Ntdj7M0To
+        skip_symbols: false

--- a/src/Serilog.Sinks.TestCorrelator/Serilog.Sinks.TestCorrelator.csproj
+++ b/src/Serilog.Sinks.TestCorrelator/Serilog.Sinks.TestCorrelator.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <Authors>Microsoft</Authors>
+    <Version></Version>
     <PackageLicenseUrl>https://github.com/Microsoft/serilog-sinks-testcorrelator/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Microsoft/serilog-sinks-testcorrelator</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/serilog-sinks-testcorrelator</RepositoryUrl>
     <PackageTags>serilog;sink;log;logging;unit;test;testing;unittest;unittesting</PackageTags>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Description>A Serilog sink that correlates log events with the code that produced them, enabling unit testing of log output.</Description>
     <Copyright>Copyright © 2017 Microsoft</Copyright>

--- a/src/Serilog.Sinks.TestCorrelator/Serilog.Sinks.TestCorrelator.csproj
+++ b/src/Serilog.Sinks.TestCorrelator/Serilog.Sinks.TestCorrelator.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/Serilog.Sinks.TestCorrelator.Tests/Serilog.Sinks.TestCorrelator.Tests.csproj
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/Serilog.Sinks.TestCorrelator.Tests.csproj
@@ -16,8 +16,4 @@
     <ProjectReference Include="..\..\src\Serilog.Sinks.TestCorrelator\Serilog.Sinks.TestCorrelator.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Serilog.Sinks.TestCorrelator.Tests/Serilog.Sinks.TestCorrelator.Tests.csproj
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/Serilog.Sinks.TestCorrelator.Tests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorTests.cs
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorTests.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Serilog.Events;
 using Xunit;
 
 namespace Serilog.Sinks.TestCorrelator.Tests
@@ -202,7 +201,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
         {
             using (var context = TestCorrelator.CreateContext())
             {
-                Log.Write(LogEventLevel.Information, "");
+                Log.Information("");
 
                 TestCorrelator.GetLogEventsFromContextGuid(context.Guid)
                     .Should()


### PR DESCRIPTION
Moved to Appveyor built in csproj patching now that it exists. I also updated the references as per the Serilog contributors recommendation.