### PR TITLE
Fix serialization bug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   major: 3
   minor: 0
-  patch: 1
+  patch: 2
 
 version: $(major).$(minor).$(patch)+{branch}-{build}
 

--- a/test/Serilog.Sinks.TestCorrelator.Tests/Serilog.Sinks.TestCorrelator.Tests.csproj
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/Serilog.Sinks.TestCorrelator.Tests.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorSinkTests.cs
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorSinkTests.cs
@@ -1,11 +1,12 @@
 ﻿using FluentAssertions;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Serilog.Sinks.TestCorrelator.Tests
 {
+    [TestClass]
     public class TestCorrelatorSinkTests
     {
-        [Fact]
+        [TestMethod]
         public void A_TestCorrelatorSink_writes_LogEvents_emited_to_it_to_a_TestCorrelator()
         {
             var logger = new LoggerConfiguration().WriteTo.Sink(new TestCorrelatorSink()).CreateLogger();

--- a/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorTests.cs
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorTests.cs
@@ -2,10 +2,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Serilog.Sinks.TestCorrelator.Tests
 {
+    [TestClass]
     public class TestCorrelatorTests
     {
         public TestCorrelatorTests()
@@ -13,7 +14,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             Log.Logger = new LoggerConfiguration().WriteTo.TestCorrelator().CreateLogger();
         }
 
-        [Fact]
+        [TestMethod]
         public void A_context_captures_all_LogEvents_emitted_to_a_TestCorrelatorContext_within_it()
         {
             using (TestCorrelator.CreateContext())
@@ -24,7 +25,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void A_context_captures_LogEvents_even_in_sub_methods()
         {
             using (TestCorrelator.CreateContext())
@@ -40,7 +41,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             Log.Information("");
         }
 
-        [Fact]
+        [TestMethod]
         public void A_context_does_not_capture_LogEvents_outside_of_it()
         {
             Guid contextGuid;
@@ -55,7 +56,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             TestCorrelator.GetLogEventsFromContextGuid(contextGuid).Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void A_context_captures_LogEvents_inside_the_same_logical_call_context()
         {
             using (TestCorrelator.CreateContext())
@@ -68,7 +69,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void
             A_context_captures_LogEvents_inside_the_same_logical_call_context_even_when_they_are_in_tasks_started_outside_of_it()
         {
@@ -90,7 +91,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
                 .ContainSingle();
         }
 
-        [Fact]
+        [TestMethod]
         public void
             A_context_does_not_capture_LogEvents_outside_the_same_logical_call_context_even_when_they_run_concurrently()
         {
@@ -124,7 +125,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             TestCorrelator.GetLogEventsFromContextGuid(contextGuid).Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void
             A_context_does_not_capture_LogEvents_outside_the_same_logical_call_context_even_when_they_are_in_tasks_started_inside_of_it()
         {
@@ -140,7 +141,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void A_context_within_a_context_adds_an_additional_context_to_LogEvents()
         {
             using (var outerContext = TestCorrelator.CreateContext())
@@ -160,7 +161,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void Getting_LogEvents_from_the_current_context_gets_LogEvents_from_the_innermost_context()
         {
             using (TestCorrelator.CreateContext())
@@ -178,7 +179,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void Getting_LogEvents_from_the_current_context_gets_LogEvents_emitted_within_sub_contexts()
         {
             using (TestCorrelator.CreateContext())
@@ -196,7 +197,7 @@ namespace Serilog.Sinks.TestCorrelator.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void A_context_does_not_enrich_LogEvents_emitted_within_it()
         {
             using (var context = TestCorrelator.CreateContext())


### PR DESCRIPTION
MSTest doesn't like it if you pass a non-serializable object to LogicalSetData. We'll use ObjectHandles instead.