### PR TITLE
Global context

### DIFF
--- a/src/Serilog.Sinks.TestCorrelator/Sinks/TestCorrelator/TestCorrelator.cs
+++ b/src/Serilog.Sinks.TestCorrelator/Sinks/TestCorrelator/TestCorrelator.cs
@@ -19,7 +19,7 @@ namespace Serilog.Sinks.TestCorrelator
 
         static readonly Subject<ContextGuidDecoratedLogEvent> ContextGuidDecoratedLogEventSubject = new Subject<ContextGuidDecoratedLogEvent>();
 
-        static ITestCorrelatorContext GlobalTestContext = new GlobalTestCorrelatorContext(Guid.Empty);
+        private static ITestCorrelatorContext _globalTestContext = new GlobalTestCorrelatorContext(Guid.Empty);
 
         /// <summary>
         /// Creates a disposable <seealso cref="ITestCorrelatorContext"/> that groups all LogEvents emitted to a <seealso cref="TestCorrelatorSink"/> within it.
@@ -40,7 +40,7 @@ namespace Serilog.Sinks.TestCorrelator
         public static ITestCorrelatorContext CreateGlobalContext()
         {
             var testCorrelatorContext = new GlobalTestCorrelatorContext(Guid.NewGuid());
-            GlobalTestContext = testCorrelatorContext;
+            _globalTestContext = testCorrelatorContext;
 
             return testCorrelatorContext;
         }
@@ -64,11 +64,10 @@ namespace Serilog.Sinks.TestCorrelator
         public static IEnumerable<LogEvent> GetLogEventsFromCurrentContext()
         {
             var currentContextGuids = GetCurrentContextGuids().ToList();
-
-            var logEvents = ContextGuidDecoratedLogEvents
+ 
+            return ContextGuidDecoratedLogEvents
                 .Where(contextGuidDecoratedLogEvent => !currentContextGuids.Except(contextGuidDecoratedLogEvent.ContextGuids).Any())
-                .Select(contextGuidDecoratedLogEvent => contextGuidDecoratedLogEvent.LogEvent);
-            return logEvents;
+                .Select(contextGuidDecoratedLogEvent => contextGuidDecoratedLogEvent.LogEvent); ;
         }
 
         /// <summary>
@@ -105,8 +104,8 @@ namespace Serilog.Sinks.TestCorrelator
         {
             var contextGuids = ContextGuids.Where(LogicalCallContext.Contains).ToList();
 
-            if (GlobalTestContext != null && GlobalTestContext.Guid != Guid.Empty)
-                contextGuids.Insert(0, GlobalTestContext.Guid);
+            if (_globalTestContext != null && _globalTestContext.Guid != Guid.Empty)
+                contextGuids.Insert(0, _globalTestContext.Guid);
 
             var contextGuidDecoratedLogEvent = new ContextGuidDecoratedLogEvent(logEvent, contextGuids);
 

--- a/src/Serilog.Sinks.TestCorrelator/Sinks/TestCorrelator/TestCorrelatorContext.cs
+++ b/src/Serilog.Sinks.TestCorrelator/Sinks/TestCorrelator/TestCorrelatorContext.cs
@@ -10,11 +10,27 @@ namespace Serilog.Sinks.TestCorrelator
             LogicalCallContext.Add(Guid);
         }
 
-        public Guid Guid { get; }
+        public Guid Guid { get; private set; }
 
         public void Dispose()
         {
             LogicalCallContext.Remove(Guid);
+            Guid = Guid.Empty;
+        }
+    }
+
+    class GlobalTestCorrelatorContext : ITestCorrelatorContext
+    {
+        public GlobalTestCorrelatorContext(Guid guid)
+        {
+            Guid = guid;
+        }
+
+        public Guid Guid { get; private set; }
+
+        public void Dispose()
+        {
+            Guid = Guid.Empty;
         }
     }
 }

--- a/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorTests.cs
+++ b/test/Serilog.Sinks.TestCorrelator.Tests/TestCorrelatorTests.cs
@@ -255,6 +255,42 @@ namespace Serilog.Sinks.TestCorrelator.Tests
         }
 
         [TestMethod]
+        public void Getting_LogEvents_from_multiple_global_contexts()
+        {
+            var globalContextGuid1 = TestCorrelator.CreateGlobalContext().Guid;
+
+            Log.Information("");
+
+            using (TestCorrelator.CreateContext())
+            {
+                Log.Information("");
+
+                using (TestCorrelator.CreateContext())
+                {
+                    Log.Information("");
+                }
+
+                TestCorrelator.GetLogEventsFromCurrentContext()
+                    .Should().HaveCount(2);
+            }
+
+            var globalContextGuid2 = TestCorrelator.CreateGlobalContext().Guid;
+
+            Log.Information("");
+
+            using (TestCorrelator.CreateContext())
+            {
+                Log.Information("");
+
+                TestCorrelator.GetLogEventsFromCurrentContext()
+                    .Should().HaveCount(1);
+            }
+
+            TestCorrelator.GetLogEventsFromContextGuid(globalContextGuid1).Should().HaveCount(3);
+            TestCorrelator.GetLogEventsFromContextGuid(globalContextGuid2).Should().HaveCount(2);
+        }
+
+        [TestMethod]
         public void Getting_LogEvents_from_the_current_context_should_return_LogEvents_from_the_context_in_which_it_was_created_even_when_enumerated_outside_of_it()
         {
             IEnumerable<LogEvent> logEventsFromCurrentContext;


### PR DESCRIPTION
Hi,
great sink! It was exactly what i need to test some async processing code that i wrote. But further down the road i noticed some LogEvents where not captured. So i checked the unit tests as suggested and found out that LogEvents outside the same logical call not captured. 
To fix that i created a Global Context in wich all LogEvents go. This change does not break the current behavior in any way. It is just an additional function. 
If you want to include this function, feel free to accept the pr.

